### PR TITLE
[Autopilot] approval for rule p1/resize-pvc-pvc-f92345ca-e9a1-11ea-91bd-000c293dc05c rule: resize-pvc

### DIFF
--- a/autopilot/resize-pvc-pvc-f92345ca-e9a1-11ea-91bd-000c293dc05c-40abc628-5795-44fd-9171-8d45fec87e4e.yaml
+++ b/autopilot/resize-pvc-pvc-f92345ca-e9a1-11ea-91bd-000c293dc05c-40abc628-5795-44fd-9171-8d45fec87e4e.yaml
@@ -1,0 +1,42 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  labels:
+    object: pvc-f92345ca-e9a1-11ea-91bd-000c293dc05c
+    rule: resize-pvc
+  name: resize-pvc-pvc-f92345ca-e9a1-11ea-91bd-000c293dc05c
+  namespace: p1
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 200Gi
+      scalepercentage: "50"
+  approvalState: approved
+status:
+  Rule:
+    Name: resize-pvc
+    Namespace: ""
+  actionPreviews:
+  - action:
+      name: resize
+      params:
+        maxsize: 200Gi
+        scalepercentage: "50"
+    expectedResult:
+      Message: PVC will resize from 20Gi to 30Gi
+    involvedObjects:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: postgres-data1
+      namespace: p1
+      ownerReferences:
+      - apiVersion: apps/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: ReplicaSet
+        name: postgres-5dbf7bd699
+        uid: f9277105-e9a1-11ea-91bd-000c293dc05c
+      uid: pvc-f92345ca-e9a1-11ea-91bd-000c293dc05c
+  lastProcessTimestamp: "2020-08-29T02:58:55Z"


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __resize-pvc__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:200Gi scalepercentage:50]
- __ExpectedResult__: PVC will resize from 20Gi to 30Gi

 
#### What objects will get affected

- PersistentVolumeClaim p1/postgres-data1 (pvc-f92345ca-e9a1-11ea-91bd-000c293dc05c)
  - Object Owner(s):
    - ReplicaSet postgres-5dbf7bd699      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
