### PR TITLE
[Autopilot] approval for rule pg1/volume-resize-pvc-7735ebe5-ebf6-11ea-91bd-000c293dc05c rule: volume-resize

### DIFF
--- a/autopilot/volume-resize-pvc-7735ebe5-ebf6-11ea-91bd-000c293dc05c-f0dc2be0-85be-47c1-a3e2-304ffe6cda7f.yaml
+++ b/autopilot/volume-resize-pvc-7735ebe5-ebf6-11ea-91bd-000c293dc05c-f0dc2be0-85be-47c1-a3e2-304ffe6cda7f.yaml
@@ -1,0 +1,44 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  finalizers:
+  - autopilot.libopenstorage.org/delete
+  labels:
+    object: pvc-7735ebe5-ebf6-11ea-91bd-000c293dc05c
+    rule: volume-resize
+  name: volume-resize-pvc-7735ebe5-ebf6-11ea-91bd-000c293dc05c
+  namespace: pg1
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 400Gi
+      scalepercentage: "100"
+  approvalState: approved
+status:
+  Rule:
+    Name: volume-resize
+    Namespace: ""
+  actionPreviews:
+  - action:
+      name: resize
+      params:
+        maxsize: 400Gi
+        scalepercentage: "100"
+    expectedResult:
+      Message: PVC will resize from 10Gi to 20Gi
+    involvedObjects:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: pgbench-data
+      namespace: pg1
+      ownerReferences:
+      - apiVersion: apps/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: ReplicaSet
+        name: pgbench-5d4d8bc778
+        uid: 74299440-ebf6-11ea-91bd-000c293dc05c
+      uid: pvc-7735ebe5-ebf6-11ea-91bd-000c293dc05c
+  lastProcessTimestamp: "2020-09-01T02:06:52Z"


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __volume-resize__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:400Gi scalepercentage:100]

#### ExpectedResult

PVC will resize from 10Gi to 20Gi
 
#### What objects will get affected

- PersistentVolumeClaim pg1/pgbench-data (pvc-7735ebe5-ebf6-11ea-91bd-000c293dc05c)
  - Object Owner(s):
    - ReplicaSet pgbench-5d4d8bc778      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
