### PR TITLE
[Autopilot] approval for rule p1/resize-pvc-pvc-1c1b15e9-ec8d-11ea-91bd-000c293dc05c rule: resize-pvc

### DIFF
--- a/autopilot/resize-pvc-pvc-1c1b15e9-ec8d-11ea-91bd-000c293dc05c-b4d50e68-48a2-4ad9-a61b-59739cc4fa7c.yaml
+++ b/autopilot/resize-pvc-pvc-1c1b15e9-ec8d-11ea-91bd-000c293dc05c-b4d50e68-48a2-4ad9-a61b-59739cc4fa7c.yaml
@@ -1,0 +1,44 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  finalizers:
+  - autopilot.libopenstorage.org/delete
+  labels:
+    object: pvc-1c1b15e9-ec8d-11ea-91bd-000c293dc05c
+    rule: resize-pvc
+  name: resize-pvc-pvc-1c1b15e9-ec8d-11ea-91bd-000c293dc05c
+  namespace: p1
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 200Gi
+      scalepercentage: "50"
+  approvalState: approved
+status:
+  Rule:
+    Name: resize-pvc
+    Namespace: ""
+  actionPreviews:
+  - action:
+      name: resize
+      params:
+        maxsize: 200Gi
+        scalepercentage: "50"
+    expectedResult:
+      Message: PVC will resize from 20Gi to 30Gi
+    involvedObjects:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: postgres-data1
+      namespace: p1
+      ownerReferences:
+      - apiVersion: apps/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: ReplicaSet
+        name: postgres-5fd64744cd
+        uid: 1c21c0ca-ec8d-11ea-91bd-000c293dc05c
+      uid: pvc-1c1b15e9-ec8d-11ea-91bd-000c293dc05c
+  lastProcessTimestamp: "2020-09-01T20:29:44Z"


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __resize-pvc__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:200Gi scalepercentage:50]

#### ExpectedResult

PVC will resize from 20Gi to 30Gi
 
#### What objects will get affected

- PersistentVolumeClaim p1/postgres-data1 (pvc-1c1b15e9-ec8d-11ea-91bd-000c293dc05c)
  - Object Owner(s):
    - ReplicaSet postgres-5fd64744cd      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
