### PR TITLE
[Autopilot] approval for rule p1/resize-pvc-pvc-cf0b124b-ec96-11ea-91bd-000c293dc05c rule: resize-pvc

### DIFF
--- a/autopilot/resize-pvc-pvc-cf0b124b-ec96-11ea-91bd-000c293dc05c-39af99c3-b2c2-4cee-a4df-568b2afb76f2.yaml
+++ b/autopilot/resize-pvc-pvc-cf0b124b-ec96-11ea-91bd-000c293dc05c-39af99c3-b2c2-4cee-a4df-568b2afb76f2.yaml
@@ -1,0 +1,44 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  finalizers:
+  - autopilot.libopenstorage.org/delete
+  labels:
+    object: pvc-cf0b124b-ec96-11ea-91bd-000c293dc05c
+    rule: resize-pvc
+  name: resize-pvc-pvc-cf0b124b-ec96-11ea-91bd-000c293dc05c
+  namespace: p1
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 200Gi
+      scalepercentage: "50"
+  approvalState: approved
+status:
+  Rule:
+    Name: resize-pvc
+    Namespace: ""
+  actionPreviews:
+  - action:
+      name: resize
+      params:
+        maxsize: 200Gi
+        scalepercentage: "50"
+    expectedResult:
+      Message: PVC will resize from 30Gi to 45Gi
+    involvedObjects:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: postgres-data1
+      namespace: p1
+      ownerReferences:
+      - apiVersion: apps/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: ReplicaSet
+        name: postgres-5fd64744cd
+        uid: cf104815-ec96-11ea-91bd-000c293dc05c
+      uid: pvc-cf0b124b-ec96-11ea-91bd-000c293dc05c
+  lastProcessTimestamp: "2020-09-02T19:52:49Z"


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __resize-pvc__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:200Gi scalepercentage:50]

#### ExpectedResult

PVC will resize from 30Gi to 45Gi
 
#### What objects will get affected

- PersistentVolumeClaim p1/postgres-data1 (pvc-cf0b124b-ec96-11ea-91bd-000c293dc05c)
  - Object Owner(s):
    - ReplicaSet postgres-5fd64744cd      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
